### PR TITLE
molecule string and backup template

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -12,7 +12,7 @@ from psi4.core import Matrix
 from psi4.driver.qcdb import cfour, hessparse 
 
 from .cluster import Cluster
-
+from .template import TemplateFileProcessor
 
 class Calculation(ABC):
     """ This is the Base class for everything calculation related in optavc. Its purpose is really to define
@@ -242,7 +242,7 @@ class AnalyticCalc(Calculation):
         
         if backup:
             backup_template_str = open(self.options.backup_template).read()
-            tfp = TemplateFileProcessor(backup_template_str, self.options)
+            tfp = TemplateFileProcessor(backup_template_str, self.options).input_file_object
             input_text = tfp.make_input(self.molecule.geom)
         else:
             input_text = self.inp_file_obj.make_input(self.molecule.geom)

--- a/template.py
+++ b/template.py
@@ -99,8 +99,7 @@ class TemplateFileProcessor(object):
             header, footer = file_string[:start], file_string[end:]
             # Replace any curly braces with double braces to prevent formatting them
             coord_str = coord_str.replace('{', '{{').replace('}', '}}')
-            body_template = re.sub('\s*(-?\d+\.?\d*)', ' {:> 17.12f}',
-                                   coord_str)
+            body_template = re.sub('\s*(-?\d+\.\d*)', ' {:> 17.12f}', coord_str)
 
         self.molecule = Molecule(xyzstring)
         self.input_file_object = InputFile(header, footer, body_template)


### PR DESCRIPTION
- [x] Two bug fixes for backup templates. Missing import and input_file_object reference
- [x] Regex used to substitute new values for coordinate  in molecule was treating C1 x y z was substituting for 1 x y z instead of x y z