### PR TITLE
fix default options broadcasting for multiple corrections

### DIFF
--- a/options.py
+++ b/options.py
@@ -1076,7 +1076,9 @@ class Options(object):
             Options.check_delta_format(val, opt_name)
         else:
             try:
-                val = [[val] * len(self.delta_templates)]
+                max_specified = max(len(self.delta_templates), len(self.delta_regexes))
+                val = [[val]] * max_specified
+                print(val)
             except TypeError:
                 return val
         Options.check_option_dtype(val, opt_name, int_allowed)

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,0 +1,41 @@
+import optavc
+from optavc import xtpl, options, template
+
+
+
+def test_delta_options():
+
+    energy_regex = 'a'
+    molpronfc = 'b'
+    molprofc = 'c'
+
+    template_dummy_string = """0 1
+    C	0.0000000	0.0000000	0.5889820
+    C	0.0000000	1.2631860	-0.2599400
+    C	0.0000000	-1.2631860	-0.2599400
+    H	0.8730160	0.0000000	1.2426200
+    H	-0.8730160	0.0000000	1.2426200
+    H	0.0000000	2.1608190	0.3554840
+    H	0.0000000	-2.1608190	0.3554840
+    H	0.8793880	1.2973360	-0.9027060
+    H	-0.8793880	1.2973360	-0.9027060
+    H	-0.8793880	-1.2973360	-0.9027060
+    H	0.8793880	-1.2973360	-0.9027060
+    """
+
+    delta_opts = {'program'            : "psi4", 
+                  'delta_templates'    : [['template.dat','template.dat'],['template.dat','template.dat']],
+                  'delta_regexes'      : [[energy_regex, energy_regex],[molpronfc, molprofc]],
+                  'delta_nslots'       : [[10,2],[4,4]],
+                  'delta_programs'     : [['psi4@master','psi4@master'],["molpro", "molpro"]],
+                  'delta_memories'     : [['50GB','5GB'],['10GB','10GB']],
+                  'delta_names'        : [['ccsd_t','mp2dz'],['fc','fc']],
+                  'delta_queues'       : [['batch','batch'],['batch','batch']],
+                  'delta_parallels'    : [['serial','serial'],['mpi','mpi']],
+                  'delta_dertypes'     : [['gradient','gradient'],['energy','energy']]}
+
+    opts_obj = options.Options(**delta_opts)
+    template_obj = template.TemplateFileProcessor(template_dummy_string, opts_obj)
+    molecule = template_obj.molecule
+
+    xtpl.Delta("GRADIENT", molecule, opts_obj)

--- a/xtpl.py
+++ b/xtpl.py
@@ -357,6 +357,7 @@ class Delta(Procedure):
         for delta_itr, delta_item in enumerate(self.delta_option_list):
             flat_delta_list[delta_itr] = [calc_option for delta_set in delta_item for calc_option
                                           in delta_set]
+            print(flat_delta_list[delta_itr])
         return flat_delta_list
 
     @staticmethod


### PR DESCRIPTION
- [x] delta default options were being broadcast as `[[option, option]]` not `[[option], [option]]` in the first broadcast
- [x] Add test for simple delta creation for case of two corrections