### PR TITLE
Fix issue when using elements with ECP in def2-tzvp

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ def final_hess_printout(hess_obj, options):
     
     psi4.core.print_out("\nThe final computed hessian is:\n\n")        
     psi4_mol_obj = hess_obj.molecule.cast_to_psi4_molecule_object(fix_com=options.fix_com, fix_orientation=options.fix_orientation)
-    wfn = psi4.core.Wavefunction.build(psi4_mol_obj, 'def2-tzvp')
+    wfn = psi4.core.Wavefunction.build(psi4_mol_obj, 'sap_helfem_small')
     wfn.set_hessian(psi4.core.Matrix.from_array(hess_obj.result))
     wfn.set_energy(hess_obj.energy)
     psi4.core.set_variable("CURRENT ENERGY", hess_obj.energy)


### PR DESCRIPTION
When the base Psi4 install doesn't include ecpint and you use optavc with an element that has an ecp in the def2-tzvp basis, it would fail even though we don't calculate any integrals. Instead, the sap_helfem_small basis is defined for all elements without an ecp. It also only contains a single contracted s-orbital, so perhaps not the best for real calculations.